### PR TITLE
Input-control

### DIFF
--- a/ChessGame.js
+++ b/ChessGame.js
@@ -1,28 +1,30 @@
+import {TextWindow, KeyBehaviour} from 'https://files.glitchtech.top/GE.js';
+
 class ChessGame {
-    static gameplayController = (textWindow=null, chessWindow=null, chessBoard=null, chessRuleset=null, renderChessTile=null) => {
-        let menuPos = 0;
+    static gameplayController = (chessGame=null) => {
         document.addEventListener("keydown", function(event) {
             const key = event.key;
+            chessGame.renderChessTile(chessGame.cursorX, chessGame.cursorY, 2);
             switch (key) {
                 case "w":
-                    if (cursorY > 0) cursorY--;
+                    if (chessGame.cursorY > 0) chessGame.cursorY--;
                     break;
                 case "s":
-                    if (cursorY < 7) cursorY++;
+                    if (chessGame.cursorY < 7) chessGame.cursorY++;
                     break;
                 case "a":
-                    if (cursorX > 0) cursorX--;
+                    if (chessGame.cursorX > 0) chessGame.cursorX--;
                     break;
                 case "d":
-                    if (cursorX < 7) cursorX++;
+                    if (chessGame.cursorX < 7) chessGame.cursorX++;
                     break;
                 case "Enter":
-                    selectedX = cursorX;
-                    selectedY = cursorY;
+                    chessGame.selectedX = chessGame.cursorX;
+                    chessGame.selectedY = chessGame.cursorY;
                     break;
                 case "Backspace":
-                    selectedX = null;
-                    selectedY = null;
+                    chessGame.selectedX = null;
+                    chessGame.selectedY = null;
                     break;
             }
         });
@@ -38,6 +40,11 @@ class ChessGame {
         console.log(this.width, this.height);
         //TODO: Make chess window below solely dependent on size of board
         this.chessWindow = new TextWindow(640, this.height, 0, 0, 0, 0, false, null);
+
+        this.cursorX = 0;
+        this.cursorY = 0;
+        this.selectionX = null;
+        this.selectionY = null;
     }
 
     render() {
@@ -108,3 +115,5 @@ class ChessGame {
         }
     }
 }
+
+export {ChessGame};

--- a/ChessGame.js
+++ b/ChessGame.js
@@ -1,4 +1,33 @@
 class ChessGame {
+    static gameplayController = (textWindow=null, chessWindow=null, chessBoard=null, chessRuleset=null, renderChessTile=null) => {
+        let menuPos = 0;
+        document.addEventListener("keydown", function(event) {
+            const key = event.key;
+            switch (key) {
+                case "w":
+                    if (cursorY > 0) cursorY--;
+                    break;
+                case "s":
+                    if (cursorY < 7) cursorY++;
+                    break;
+                case "a":
+                    if (cursorX > 0) cursorX--;
+                    break;
+                case "d":
+                    if (cursorX < 7) cursorX++;
+                    break;
+                case "Enter":
+                    selectedX = cursorX;
+                    selectedY = cursorY;
+                    break;
+                case "Backspace":
+                    selectedX = null;
+                    selectedY = null;
+                    break;
+            }
+        });
+    }
+
     constructor(chessRuleset) {
         this.chessRuleset = chessRuleset;
         this.boardData = this.chessRuleset.boardData["attributes"];

--- a/ChessGame.js
+++ b/ChessGame.js
@@ -1,0 +1,81 @@
+class ChessGame {
+    constructor(chessRuleset) {
+        this.chessRuleset = chessRuleset;
+        this.boardData = this.chessRuleset.boardData["attributes"];
+        this.pieces = this.chessRuleset.pieces;
+        this.chessBoard = this.initChessBoard(this.boardData);
+        this.width = this.boardData["width"] * this.boardData["tileWidth"] * 8;
+        this.height = this.boardData["height"] * this.boardData["tileHeight"] * 16;
+        console.log(this.width, this.height);
+        //TODO: Make chess window below solely dependent on size of board
+        this.chessWindow = new TextWindow(640, this.height, 0, 0, 0, 0, false, null);
+    }
+
+    render() {
+        for (let i = 0; i < this.boardData["height"]; i++) {
+            for (let j = 0; j < this.boardData["width"]; j++) {
+                renderChessTile(i, j);
+            }
+        }
+    }
+
+    initChessBoard() {
+        let startingChessBoard = this.boardData["setup"];
+        let players = this.boardData["players"];
+        let pattern = this.boardData["pattern"];
+    
+        let chessBoard = [];
+        for (let i = 0; i < 8; i++) {
+            chessBoard[i] = [];
+            for (let j = 0; j < 8; j++) {
+                for (let player in players) {
+                    let player_delimiter = players[player]["delimiter"];
+                    if (startingChessBoard[j][i].includes(player_delimiter)) {
+                        let separatedValue = startingChessBoard[j][i].replace(player_delimiter, '');
+                        chessBoard[i][j] = {
+                            "tile": {
+                                "x": i,
+                                "y": j,
+                                "pattern": pattern["colors"][pattern["setup"][i][j]], // Super awesome pattern system
+                            },
+                            "piece": {
+                                "player": player_delimiter,
+                                "pieceName": separatedValue,
+                                "color": players[player]["color"],
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return chessBoard;
+    }
+
+    renderChessTile(i, j, backgroundColor=null) {
+        let chessPiece = this.chessPieces[this.chessBoard[i][j]["piece"]["pieceName"]]["sprite"];
+        let tileColor = this.chessBoard[i][j]["tile"]["pattern"];
+    
+        if (backgroundColor != null) {
+            tileColor = backgroundColor;
+        }
+    
+        let pieceColor = this.chessBoard[i][j]["piece"]["color"];
+        let color = [tileColor, pieceColor];
+    
+        for (let k = 0; k < this.boardData["tileHeight"]; k++) {
+            let rowOffset = k * 16;
+            let spaces = ' '.repeat(this.boardData["tileWidth"]);
+            this.chessWindow.drawText(spaces, i*(this.boardData["tileWidth"]*8), j*(this.boardData["tileHeight"]*16)+rowOffset, color);
+            console.log(spaces);
+        }
+    
+        let pieceYOffset = 16*this.boardData["pieceYOffset"];
+        let pieceXOffset = 8*this.boardData["pieceXOffset"];
+    
+        for (let k = 0; k < this.boardData["pieceHeight"]; k++) {
+            let rowOffset = k * 16;
+            // We do not check for pieceWidth because in Freakbob we trust
+            this.chessWindow.drawText(chessPiece[k], i*(this.boardData["tileWidth"]*8)+pieceXOffset, j*(this.boardData["tileHeight"]*16)+rowOffset+pieceYOffset, color);
+        }
+    }
+}

--- a/ChessGame.js
+++ b/ChessGame.js
@@ -39,7 +39,16 @@ class ChessGame {
         this.height = this.boardData["height"] * this.boardData["tileHeight"] * 16;
         console.log(this.width, this.height);
         //TODO: Make chess window below solely dependent on size of board
-        this.chessWindow = new TextWindow(640, this.height, 0, 0, 0, 0, false, null);
+        this.chessWindow = new TextWindow({
+            width: 640, 
+            height: this.height, 
+            x: 0, 
+            y: 0, 
+            rows: 0, 
+            cols: 0, 
+            editable: false, 
+            text: ""
+        });
 
         this.cursorX = 0;
         this.cursorY = 0;
@@ -50,7 +59,7 @@ class ChessGame {
     render() {
         for (let i = 0; i < this.boardData["height"]; i++) {
             for (let j = 0; j < this.boardData["width"]; j++) {
-                renderChessTile(i, j);
+                this.renderChessTile(i, j);
             }
         }
     }
@@ -88,7 +97,7 @@ class ChessGame {
     }
 
     renderChessTile(i, j, backgroundColor=null) {
-        let chessPiece = this.chessPieces[this.chessBoard[i][j]["piece"]["pieceName"]]["sprite"];
+        let chessPiece = this.pieces[this.chessBoard[i][j]["piece"]["pieceName"]]["sprite"];
         let tileColor = this.chessBoard[i][j]["tile"]["pattern"];
     
         if (backgroundColor != null) {

--- a/index.html
+++ b/index.html
@@ -6,5 +6,6 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body></body>
+<script src="ChessGame.js"></script>
 <script src="main.js" type="module"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,6 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body></body>
-<script src="ChessGame.js"></script>
+<script src="ChessGame.js" type="module"></script>
 <script src="main.js" type="module"></script>
 </html>

--- a/main.js
+++ b/main.js
@@ -34,8 +34,8 @@ function main() {
         });
     }
 
-    gameWindow = new TextWindow(640, 384, 0, 0, 0, 0, false, "", menuBehaviour, {menuPos: 0});
-    const gameWindow = new TextWindow({
+    //gameWindow = new TextWindow(640, 384, 0, 0, 0, 0, false, "", menuBehaviour, {menuPos: 0});
+    gameWindow = new TextWindow({
         width: 640,
         height: 384,
         x: 0,
@@ -46,13 +46,13 @@ function main() {
         text: "",
         keyRules: menuBehaviour,
         keyRulesParameters: {menuPos: 0}
-     });
-    mainMenu();
+    });
+    mainMenu(gameWindow);
 }
 
 
 
-function mainMenu() {
+function mainMenu(gamewindow) {
     //This is the main menu
     gameWindow.drawText("> Main Menu", 288, 0);
     gameWindow.drawText("> Play Chess", 0, 16);

--- a/main.js
+++ b/main.js
@@ -36,35 +36,6 @@ function main() {
             }
         });
     }
-    
-    const chessBehaviour = (textWindow=null, chessWindow=null, chessBoard=null, chessRuleset=null, renderChessTile=null) => {
-        let menuPos = 0;
-        document.addEventListener("keydown", function(event) {
-            const key = event.key;
-            switch (key) {
-                case "w":
-                    if (cursorY > 0) cursorY--;
-                    break;
-                case "s":
-                    if (cursorY < 7) cursorY++;
-                    break;
-                case "a":
-                    if (cursorX > 0) cursorX--;
-                    break;
-                case "d":
-                    if (cursorX < 7) cursorX++;
-                    break;
-                case "Enter":
-                    selectedX = cursorX;
-                    selectedY = cursorY;
-                    break;
-                case "Backspace":
-                    selectedX = null;
-                    selectedY = null;
-                    break;
-            }
-        });
-    }
 
     gameWindow = new TextWindow(640, 384, 0, 0, 0, 0, false, menuBehaviour);
 

--- a/main.js
+++ b/main.js
@@ -1,6 +1,10 @@
 import {CanvasWindow, TextWindow, KeyBehaviour} from 'https://files.glitchtech.top/GE.js';
 const canvasWindow = new CanvasWindow(640, 384, main); // Allows for a 80x24 text grid with 8x16 characters
 let gameWindow;
+let cursorX = 0;
+let cursorY = 0;
+let selectionX = null;
+let selectionY = null;
 
 function main() {
     const menuBehaviour = (textWindow=null) => {
@@ -32,10 +36,33 @@ function main() {
             }
         });
     }
-    const chessBehaviour = (textWindow=null) => {
+    
+    const chessBehaviour = (textWindow=null, chessWindow=null, chessBoard=null, chessRuleset=null, renderChessTile=null) => {
         let menuPos = 0;
         document.addEventListener("keydown", function(event) {
             const key = event.key;
+            switch (key) {
+                case "w":
+                    if (cursorY > 0) cursorY--;
+                    break;
+                case "s":
+                    if (cursorY < 7) cursorY++;
+                    break;
+                case "a":
+                    if (cursorX > 0) cursorX--;
+                    break;
+                case "d":
+                    if (cursorX < 7) cursorX++;
+                    break;
+                case "Enter":
+                    selectedX = cursorX;
+                    selectedY = cursorY;
+                    break;
+                case "Backspace":
+                    selectedX = null;
+                    selectedY = null;
+                    break;
+            }
         });
     }
 
@@ -113,85 +140,7 @@ function selectionMenu() {
     });
 }
 
-function game(chessRuleset) {
-    let gameWindow = new TextWindow(640, 384, 0, 0, 0, 0, false, null);
-    gameWindow.drawText("=== Chess ===", 288, 0);
-
-    let chessBoard = initChessBoard(chessRuleset.boardData);
-
-    const chessPieces = {
-        "blank": ["   ", "   ", "   "], // Empty
-        "rook": ["╚╬╝", ") (", "[_]"], // Rook
-        "knight": ["T\\ ", "|\\)", "[_]"], // Knight
-        "bishop": ["(+)", ") (", "[_]"], // Bishop
-        "queen": [" . ", ") (", "[_]"], // Queen
-        "king": [" ┼ ", ") (", "[_]"], // King
-        "pawn": ["   ", " o ", "[_]"], // Pawn
-    }
-
-    renderChessBoard(gameWindow, chessBoard, chessRuleset);
-
-};
-
-function initChessBoard(boardData) {
-    let startingChessBoard = boardData["attributes"]["setup"];
-    let players = boardData["attributes"]["players"];
-    let pattern = boardData["attributes"]["pattern"];
-
-    let chessBoard = [];
-    for (let i = 0; i < 8; i++) {
-        chessBoard[i] = [];
-        for (let j = 0; j < 8; j++) {
-            for (let player in players) {
-                let player_delimiter = players[player]["delimiter"];
-                if (startingChessBoard[j][i].includes(player_delimiter)) {
-                    let separatedValue = startingChessBoard[j][i].replace(player_delimiter, '');
-                    chessBoard[i][j] = {
-                        "tile": {
-                            "x": i,
-                            "y": j,
-                            "pattern": pattern["colors"][pattern["setup"][i][j]], // Super awesome pattern system
-                        },
-                        "piece": {
-                            "player": player_delimiter,
-                            "pieceName": separatedValue,
-                            "color": players[player]["color"],
-                        }
-                    }
-                }
-            }
-        }
-    }
-    console.log(chessBoard);
-    return chessBoard;
-}
-
-function renderChessBoard(chessWindow, chessBoard, chessRuleset) {
-    let chessPieces = chessRuleset.pieces;
-    let boardData = chessRuleset.boardData["attributes"];
-    for (let i = 0; i < boardData["height"]; i++) {
-        for (let j = 0; j < boardData["width"]; j++) {
-            let chessPiece = chessPieces[chessBoard[i][j]["piece"]["pieceName"]]["sprite"];
-            let tileColor = chessBoard[i][j]["tile"]["pattern"];
-            let pieceColor = chessBoard[i][j]["piece"]["color"];
-            let color = [tileColor, pieceColor];
-
-            for (let k = 0; k < boardData["tileHeight"]; k++) {
-                let rowOffset = k * 16;
-                let spaces = ' '.repeat(boardData["tileWidth"]);
-                chessWindow.drawText(spaces, i*(boardData["tileWidth"]*8), j*(boardData["tileHeight"]*16)+rowOffset, color);
-                console.log(spaces);
-            }
-
-            let pieceYOffset = 16*boardData["pieceYOffset"];
-            let pieceXOffset = 8*boardData["pieceXOffset"];
-
-            for (let k = 0; k < boardData["pieceHeight"]; k++) {
-                let rowOffset = k * 16;
-                // We do not check for pieceWidth because in Freakbob we trust
-                chessWindow.drawText(chessPiece[k], i*(boardData["tileWidth"]*8)+pieceXOffset, j*(boardData["tileHeight"]*16)+rowOffset+pieceYOffset, color);
-            }
-            
-        }
-    }
+async function game(chessRuleset) {
+    let chessGame = new ChessGame(chessRuleset);
+    chessGame.render();
 }

--- a/main.js
+++ b/main.js
@@ -1,35 +1,32 @@
 import {CanvasWindow, TextWindow, KeyBehaviour} from 'https://files.glitchtech.top/GE.js';
+import {ChessGame} from "./ChessGame.js";
 const canvasWindow = new CanvasWindow(640, 384, main); // Allows for a 80x24 text grid with 8x16 characters
 let gameWindow;
-let cursorX = 0;
-let cursorY = 0;
-let selectionX = null;
-let selectionY = null;
 
 function main() {
-    const menuBehaviour = (textWindow=null) => {
+    const menuBehaviour = (textWindow=null, params=null) => {
         let menuPos = 0;
         document.addEventListener("keydown", function(event) {
             const key = event.key;
-            if  ((key === "w" || key === "s") && (menuPos != -1 && menuPos != 3)) {
-                textWindow.drawText(">", 0, 0+(16*(menuPos+1)));
+            if  ((key === "w" || key === "s") && (params.menuPos != -1 && params.menuPos != 3)) {
+                textWindow.drawText(">", 0, 0+(16*(params.menuPos+1)));
             }
-            if ( key === "w" && menuPos != 0) {
-                menuPos--;
-                textWindow.drawText(">", 0, 0+(16*(menuPos+1)), [15,0]);
-            } else if (key === "s" && menuPos != 2) {
-                menuPos++;
-                textWindow.drawText(">", 0, 0+(16*(menuPos+1)), [15,0]);
+            if ( key === "w" && params.menuPos != 0) {
+                params.menuPos--;
+                textWindow.drawText(">", 0, 0+(16*(params.menuPos+1)), [15,0]);
+            } else if (key === "s" && params.menuPos != 2) {
+                params.menuPos++;
+                textWindow.drawText(">", 0, 0+(16*(params.menuPos+1)), [15,0]);
             } else if (key === "Enter") {
-                if (menuPos === 0) {
+                if (params.menuPos === 0) {
                     // Start
                     textWindow.drawText("An Error Occured", 272, [0, 12]);
                     textWindow.clearScreen();
                     selectionMenu();
-                } else if (menuPos === 1) {
+                } else if (params.menuPos === 1) {
                     // Options
                     textWindow.drawText("An Error Occured", 272, [0, 12]);
-                } else if (menuPos === 2) {
+                } else if (params.menuPos === 2) {
                     // Exit
                     textWindow.drawText("An Error Occured", 272, [0, 12]);
                 }
@@ -37,8 +34,19 @@ function main() {
         });
     }
 
-    gameWindow = new TextWindow(640, 384, 0, 0, 0, 0, false, menuBehaviour);
-
+    gameWindow = new TextWindow(640, 384, 0, 0, 0, 0, false, "", menuBehaviour, {menuPos: 0});
+    const gameWindow = new TextWindow({
+        width: 640,
+        height: 384,
+        x: 0,
+        y: 0,
+        rows: 0,
+        cols: 0,
+        editable: false,
+        text: "",
+        keyRules: menuBehaviour,
+        keyRulesParameters: {menuPos: 0}
+     });
     mainMenu();
 }
 


### PR DESCRIPTION
Migrated ChessGame object to ChessGame.js. This way, we can properly dispose of TextWindow references and keyhooks in order to reset for correct input control during gameplay. This required a rewrite of GlitchEngineJS to support object-based constructors for TextWindow and GraphicWindow and has already been committed there. Approve this ASAP to unbreak main.